### PR TITLE
throw IntegrationError instead of generic error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### 0.1.1 - 2022-03-27
+
+- throw an `IntegrationError` from the client instead of generic error.
+
 ### 0.1.0 - 2022-03-14
 
 - Added `device42_account`, `device42_enduser`, and `device42_device` entities.

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import {
+  IntegrationError,
   IntegrationProviderAPIError,
   IntegrationProviderAuthenticationError,
   IntegrationProviderAuthorizationError,
@@ -138,7 +139,10 @@ export class APIClient {
           });
         }
       } else {
-        throw err;
+        throw new IntegrationError({
+          message: err.message,
+          code: (err as Error).name,
+        });
       }
     }
   }


### PR DESCRIPTION
# Description

This changes the error type throw to be `IntegrationError` rather than a generic error.
